### PR TITLE
Improvements to follow serialization + library compatabilities

### DIFF
--- a/test_project/api-schema-1.0.json
+++ b/test_project/api-schema-1.0.json
@@ -408,7 +408,7 @@
             "clip": "O2O,$clipResponse,optional",
             "user_following_count": "int",
             "user_followers_count": "int",
-            "followed": "boolean"
+            "follow_id": "int,optional"
         }},
         {"$userRequest": {
             "email": "string,optional",

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -212,6 +212,7 @@ REST_FRAMEWORK = {
         'yak.rest_core.permissions.IsOwnerOrReadOnly',
     ),
     'PAGINATE_BY': 20,
+    'PAGE_SIZE': 20,
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.ext.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.SessionAuthentication',

--- a/test_project/test_app/api/serializers.py
+++ b/test_project/test_app/api/serializers.py
@@ -2,32 +2,20 @@ from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from test_project.test_app.models import Post
 from yak.rest_core.serializers import YAKModelSerializer
-from yak.rest_social_network.serializers import LikedMixin
+from yak.rest_social_network.serializers import LikedMixin, FollowedMixin
 from yak.rest_user.serializers import AuthSerializerMixin
 
 
 User = get_user_model()
 
 
-class ProjectUserSerializer(AuthSerializerMixin, YAKModelSerializer):
+class ProjectUserSerializer(FollowedMixin, AuthSerializerMixin, YAKModelSerializer):
     class Meta:
         model = User
         fields = ('email', 'id', 'username', 'fullname', 'thumbnail', 'original_photo', 'small_photo', 'large_photo',
-                  'about', 'user_following_count', 'user_followers_count', 'followed')
+                  'about', 'user_following_count', 'user_followers_count', 'follow_id')
 
-    followed = serializers.SerializerMethodField()
-
-    def get_followed(self, obj):
-        # Adding this helps verify that `request` is passed along in the context for serializers that use YAK's
-        # `UserSerializer` nested
-        followed = False
-        request = self.context['request']
-
-        if request.user.is_authenticated():
-            user_content_type = self.get_content_type(obj)
-            followed = request.user.following.filter(content_type=user_content_type, object_id=obj.pk).exists()
-
-        return followed
+    follow_id = serializers.SerializerMethodField()
 
 
 class PostSerializer(YAKModelSerializer, LikedMixin):

--- a/test_project/test_app/tests/factories.py
+++ b/test_project/test_app/tests/factories.py
@@ -25,7 +25,7 @@ class UserFactory(factory.DjangoModelFactory):
         user.save()
         oauth_toolkit_version = [int(num) for num in oauth2_provider.__version__.split('.')]
         # If we're using version 0.8.0 or higher
-        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[0] >= 8:
+        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[1] >= 8:
             AccessToken.objects.create(user=user,
                                        application=user.oauth2_provider_application.first(),
                                        token='token{}'.format(user.id),

--- a/yak/rest_core/utils.py
+++ b/yak/rest_core/utils.py
@@ -28,3 +28,11 @@ def get_class(path):
     module = importlib.import_module(module_path)
     _class = getattr(module, class_name)
     return _class
+
+
+def get_package_version(package):
+    """
+    Return the version number of a Python package as a list of integers
+    e.g., 1.7.2 will return [1, 7, 2]
+    """
+    return [int(num) for num in package.__version__.split('.')]

--- a/yak/rest_social_network/views.py
+++ b/yak/rest_social_network/views.py
@@ -2,6 +2,7 @@ import rest_framework
 from rest_framework.response import Response
 from rest_framework import viewsets, status, generics
 from rest_framework.decorators import detail_route, list_route
+from yak.rest_core.utils import get_package_version
 from yak.rest_social_network.models import Tag, Comment, Follow, Flag, Share, Like
 from yak.rest_social_network.serializers import TagSerializer, CommentSerializer, FollowSerializer, FlagSerializer, \
     ShareSerializer, LikeSerializer
@@ -14,7 +15,7 @@ __author__ = 'baylee'
 
 
 User = get_user_model()
-drf_version = [int(num) for num in rest_framework.__version__.split('.')]
+drf_version = get_package_version(rest_framework)
 
 
 class TagViewSet(viewsets.ModelViewSet):

--- a/yak/rest_social_network/views.py
+++ b/yak/rest_social_network/views.py
@@ -3,7 +3,7 @@ from rest_framework import viewsets, status, generics
 from rest_framework.decorators import detail_route, list_route
 from yak.rest_social_network.models import Tag, Comment, Follow, Flag, Share, Like
 from yak.rest_social_network.serializers import TagSerializer, CommentSerializer, FollowSerializer, FlagSerializer, \
-    ShareSerializer, FollowPaginationSerializer, LikeSerializer
+    ShareSerializer, LikeSerializer
 from yak.rest_user.serializers import UserSerializer
 from yak.rest_user.views import UserViewSet
 from django.contrib.auth import get_user_model
@@ -90,14 +90,12 @@ class SocialUserViewSet(UserViewSet):
     def following(self, request, pk):
         requested_user = User.objects.get(pk=pk)
         following = requested_user.user_following()
-        page = self.paginate_queryset(following)
-        serializer = FollowPaginationSerializer(instance=page, context={'request': request})
+        serializer = FollowSerializer(instance=following, many=True, context={'request': request})
         return Response(serializer.data)
 
     @detail_route(methods=['get'])
     def followers(self, request, pk):
         requested_user = User.objects.get(pk=pk)
-        follower = requested_user.user_followers()
-        page = self.paginate_queryset(follower)
-        serializer = FollowPaginationSerializer(instance=page, context={'request': request})
+        followers = requested_user.user_followers()
+        serializer = FollowSerializer(instance=followers, many=True, context={'request': request})
         return Response(serializer.data)

--- a/yak/rest_user/serializers.py
+++ b/yak/rest_user/serializers.py
@@ -6,13 +6,14 @@ import oauth2_provider
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 from yak.rest_core.serializers import YAKModelSerializer
+from yak.rest_core.utils import get_package_version
 from yak.settings import yak_settings
 
 __author__ = 'baylee'
 
 
 User = get_user_model()
-oauth_toolkit_version = [int(num) for num in oauth2_provider.__version__.split('.')]
+oauth_toolkit_version = get_package_version(oauth2_provider)
 
 
 class AuthSerializerMixin(object):
@@ -63,19 +64,18 @@ class LoginSerializer(serializers.ModelSerializer):
         model = User
         fields = ('client_id', 'client_secret')
 
-    def get_client_id(self, obj):
+    def get_application(self, obj):
         # If we're using version 0.8.0 or higher
         if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[1] >= 8:
-            return obj.oauth2_provider_application.first().client_id
+            return obj.oauth2_provider_application.first()
         else:
-            return obj.application_set.first().client_id
+            return obj.application_set.first()
+
+    def get_client_id(self, obj):
+        return self.get_application(obj).client_id
 
     def get_client_secret(self, obj):
-        # If we're using version 0.8.0 or higher
-        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[1] >= 8:
-            return obj.oauth2_provider_application.first().client_secret
-        else:
-            return obj.application_set.first().client_secret
+        return self.get_application(obj).client_secret
 
 
 class SignUpSerializer(AuthSerializerMixin, LoginSerializer):

--- a/yak/rest_user/serializers.py
+++ b/yak/rest_user/serializers.py
@@ -65,14 +65,14 @@ class LoginSerializer(serializers.ModelSerializer):
 
     def get_client_id(self, obj):
         # If we're using version 0.8.0 or higher
-        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[0] >= 8:
+        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[1] >= 8:
             return obj.oauth2_provider_application.first().client_id
         else:
             return obj.application_set.first().client_id
 
     def get_client_secret(self, obj):
         # If we're using version 0.8.0 or higher
-        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[0] >= 8:
+        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[1] >= 8:
             return obj.oauth2_provider_application.first().client_secret
         else:
             return obj.application_set.first().client_secret

--- a/yak/rest_user/serializers.py
+++ b/yak/rest_user/serializers.py
@@ -2,6 +2,7 @@ import base64
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.core.validators import RegexValidator
+import oauth2_provider
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 from yak.rest_core.serializers import YAKModelSerializer
@@ -11,6 +12,7 @@ __author__ = 'baylee'
 
 
 User = get_user_model()
+oauth_toolkit_version = [int(num) for num in oauth2_provider.__version__.split('.')]
 
 
 class AuthSerializerMixin(object):
@@ -62,10 +64,18 @@ class LoginSerializer(serializers.ModelSerializer):
         fields = ('client_id', 'client_secret')
 
     def get_client_id(self, obj):
-        return obj.oauth2_provider_application.first().client_id
+        # If we're using version 0.8.0 or higher
+        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[0] >= 8:
+            return obj.oauth2_provider_application.first().client_id
+        else:
+            return obj.application_set.first().client_id
 
     def get_client_secret(self, obj):
-        return obj.oauth2_provider_application.first().client_secret
+        # If we're using version 0.8.0 or higher
+        if oauth_toolkit_version[0] >= 0 and oauth_toolkit_version[0] >= 8:
+            return obj.oauth2_provider_application.first().client_secret
+        else:
+            return obj.application_set.first().client_secret
 
 
 class SignUpSerializer(AuthSerializerMixin, LoginSerializer):


### PR DESCRIPTION
@rmutter for review

- We updated django-oauth-toolkit (https://github.com/yeti/YAK-server/commit/55e1d7df097cf8a9c09f9459d5395975c5a905ed) in `test_requirements.txt` but never updated `setup.py`, which still allowed for installation of v0.7.2. Rather than updating the version, I've included a version conditional so this still works with the older library version
- DRF >= 3.1 doesn't support `PaginationSerializer`
- DRF >= 3.1 deprecates `PAGINATE_BY` in favor of `PAGE_SIZE`
- added `FollowedMixin` similar to `LikedMixin` and added tests for both