### PR TITLE
Fixed #19: Use `.get` instead of `[]` indexing

### DIFF
--- a/yak/rest_core/test.py
+++ b/yak/rest_core/test.py
@@ -184,7 +184,7 @@ class SchemaTestCase(APITestCaseWithAssertions):
                     # Else grab the first one in the list
                     if len(new_data_object) == 0:
                         continue
-                    new_data_object = new_data_object[0]
+                    new_data_object = new_data_object.get(0, new_data_object)
 
                 self.check_schema_keys(new_data_object, self.schema_objects[new_schema_object])
 


### PR DESCRIPTION
- Set default to itself

@baylee, @rmutter: Did some debugging with this on "Where's Yeti" and found that this line was causing issues because `new_data_object` was an OrderedDict and not a list (so trying to get an item at index 0 was causing KeyErrors). 

This line change should maintain old functionality while at the same time enable me to use SchemaTestCase with Where's Yeti. 