### PR TITLE
Fix import statement in `yak/rest_social_auth_views.py`

### DIFF
--- a/yak/rest_social_auth/views.py
+++ b/yak/rest_social_auth/views.py
@@ -6,7 +6,7 @@ from rest_framework.decorators import detail_route
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from social.apps.django_app import load_strategy
+from social.apps.django_app.utils import load_strategy
 from social.apps.django_app.default.models import UserSocialAuth
 from social.apps.django_app.utils import load_backend
 from social.backends.oauth import BaseOAuth1, BaseOAuth2


### PR DESCRIPTION
- `from social.apps.django_app import load_strategy` ->
  `from social.apps.django_app.utils import load_strategy`

@baylee, I was getting `ImportError`s from all the tests on the [GottaGo server](https://github.com/yeti/gottago-server/pull/77) regarding the method `load_strategy`. It wouldn't import unless I made the change above. That being said, we are using the nearly the same installations for python-social-auth and Django as in Basicspace.

In any event, it resolved all the errors I was getting while testing GottaGo server. I'm confident to merge this if there's no other issues! 