### PR TITLE
Adds ability to customize push notification handling function

### DIFF
--- a/test_project/test_app/tests/test_notifications.py
+++ b/test_project/test_app/tests/test_notifications.py
@@ -15,6 +15,9 @@ from yak.settings import yak_settings
 
 User = get_user_model()
 
+def mockPushNotificationHandler(receiver, message, deep_link=None):
+    return { "hello": "world" } 
+
 
 class NotificationsTestCase(SchemaTestCase):
     def setUp(self):
@@ -65,6 +68,13 @@ class NotificationsTestCase(SchemaTestCase):
         message = "<h1>You have a notification!</h1>"
         response = send_push_notification(self.receiver, message)
         self.assertEqual(response["status_code"], 200)
+
+    @mock.patch('yak.rest_notifications.utils.yak_settings')
+    def test_push_notification_sent_custom_handler(self, mock_settings):
+        mock_settings.PUSH_NOTIFICATION_HANDLER = "test_project.test_app.tests.test_notifications.mockPushNotificationHandler"
+        message = "<h1>You have a notification!</h1>"
+        response = send_push_notification(self.receiver, message)
+        self.assertEqual(response["hello"], "world")
 
     def test_create_notification(self):
         notification_count = Notification.objects.count()

--- a/test_project/test_app/tests/test_notifications.py
+++ b/test_project/test_app/tests/test_notifications.py
@@ -15,8 +15,9 @@ from yak.settings import yak_settings
 
 User = get_user_model()
 
+
 def mockPushNotificationHandler(receiver, message, deep_link=None):
-    return { "hello": "world" } 
+    return {"hello": "world"}
 
 
 class NotificationsTestCase(SchemaTestCase):
@@ -71,7 +72,8 @@ class NotificationsTestCase(SchemaTestCase):
 
     @mock.patch('yak.rest_notifications.utils.yak_settings')
     def test_push_notification_sent_custom_handler(self, mock_settings):
-        mock_settings.PUSH_NOTIFICATION_HANDLER = "test_project.test_app.tests.test_notifications.mockPushNotificationHandler"
+        mock_settings.PUSH_NOTIFICATION_HANDLER = "test_project.test_app.tests." \
+                                                  "test_notifications.mockPushNotificationHandler"
         message = "<h1>You have a notification!</h1>"
         response = send_push_notification(self.receiver, message)
         self.assertEqual(response["hello"], "world")

--- a/yak/rest_notifications/utils.py
+++ b/yak/rest_notifications/utils.py
@@ -4,6 +4,7 @@ import requests
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.utils.html import strip_tags
+from django.utils.module_loading import import_string
 from pypushwoosh import constants
 from pypushwoosh.client import PushwooshClient
 
@@ -16,7 +17,7 @@ def submit_to_pushwoosh(request_data):
     return response.json()
 
 
-def send_push_notification(receiver, message, deep_link=None):
+def send_pushwoosh_notification(receiver, message, deep_link=None):
     notification_data = {
         'content': message,
         'send_date': constants.SEND_DATE_NOW,
@@ -38,6 +39,9 @@ def send_push_notification(receiver, message, deep_link=None):
 
     return submit_to_pushwoosh(request_data)
 
+def send_push_notification(receiver, message, deep_link=None):
+    notification_handler = import_string(yak_settings.PUSH_NOTIFICATION_HANDLER)
+    return notification_handler(receiver, message, deep_link=None)
 
 def send_email_notification(receiver, message, reply_to=None):
     headers = {}

--- a/yak/rest_notifications/utils.py
+++ b/yak/rest_notifications/utils.py
@@ -39,9 +39,11 @@ def send_pushwoosh_notification(receiver, message, deep_link=None):
 
     return submit_to_pushwoosh(request_data)
 
+
 def send_push_notification(receiver, message, deep_link=None):
     notification_handler = import_string(yak_settings.PUSH_NOTIFICATION_HANDLER)
     return notification_handler(receiver, message, deep_link=None)
+
 
 def send_email_notification(receiver, message, reply_to=None):
     headers = {}

--- a/yak/settings.py
+++ b/yak/settings.py
@@ -63,6 +63,7 @@ DEFAULTS = {
     'EMAIL_NOTIFICATION_SUBJECT': 'Test Project Notification',
     'PUSHWOOSH_AUTH_TOKEN': "",
     'PUSHWOOSH_APP_CODE': "",
+    'PUSH_NOTIFICATION_HANDLER': "yak.rest_notifications.utils.send_pushwoosh_notification",
     'SOCIAL_SHARE_DELAY': 60,
     'USE_FACEBOOK_OG': False,
     'FACEBOOK_OG_NAMESPACE': "",


### PR DESCRIPTION
This change allows users to specify a custom function that will be called when sending push notifications. This will allow the user to use a push notification provider other than Pushwoosh (FCM in our case).

Not sure if this is a feature that is needed/wanted in this library, but figured I'd post a PR anyways since we made the change in our fork 😸